### PR TITLE
feat: added a button on top nav bar that links to the admin site

### DIFF
--- a/intro_project/intro_app/templates/intro_app/homeNotSignedIn.html
+++ b/intro_project/intro_app/templates/intro_app/homeNotSignedIn.html
@@ -104,6 +104,9 @@
             {% if request.user.is_authenticated %}
             <a href="/logout/" class="sign-in">Sign out</a>
             {% endif %}
+            {% if request.user.is_staff %}
+            <a href="/admin/" class="admin-sign-in">Admin Site</a>
+            {% endif %}
         </div>
 
         <!-- Loop through each post -->


### PR DESCRIPTION
This was extremely simple, just needed to add one line to the homepage html file. Essentially, if an admin user is logged in, they will have an option on the top nav bar to go to the admin site. Upon clicking on that, they will go to the admin site where they can delete posts and comments (they will not need to re-log in as an admin on that site).